### PR TITLE
Use semantic version sorting for installer discovery

### DIFF
--- a/affinity_cli/installer_discovery.py
+++ b/affinity_cli/installer_discovery.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
+from packaging.version import Version
+
 PRODUCT_NAMES = {
     "photo": "Affinity Photo",
     "designer": "Affinity Designer",
@@ -59,7 +61,9 @@ class InstallerDiscovery:
                     path=file,
                 )
             )
-        installers.sort(key=lambda item: (item.product, item.version, item.file_version))
+        installers.sort(
+            key=lambda item: (item.product, item.version, Version(item.file_version))
+        )
         return installers
 
     def select_installer(


### PR DESCRIPTION
## Summary
- use `packaging.version.Version` to compare installer `file_version` values
- ensure installer lists remain sorted correctly with semantic version ordering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918992c664c83258ccaeaf94d70e088)